### PR TITLE
Allow social links in footer to be deactivated

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,8 +19,8 @@
         <li>
           <a href="https://instagram.com/{{site.instagram}}" target="_blank" title="Instagram">
             <svg class="iconsvg"><use xlink:href="#instagram"></use></svg>
-          </li>
-        </a>
+          </a>
+        </li>
         <li>
           <a href="{{site.mastodon}}" target="_blank" title="Mastodon">
             <svg class="iconsvg"><use xlink:href="#mastodon"></use></svg>
@@ -45,6 +45,7 @@
           <a href="https://github.com/{{site.github}}" target="_blank" title="GitHub">
             <svg class="iconsvg"><use xlink:href="#github"></use></svg>
           </a>
+        </li>
         <li>
           <a href="{{'/contact' | absolute_url}}" title="Email">
             <svg class="iconsvg"><use xlink:href="#envelope"></use></svg>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,41 +11,55 @@
             <svg class="iconsvg"><use xlink:href="#slack"></use></svg>
           </a>
         </li>
-        <li>
-          <a href="https://youtube.com/{{site.youtube_page}}" target="_blank" title="YouTube">
-            <svg class="iconsvg"><use xlink:href="#youtube"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="https://instagram.com/{{site.instagram}}" target="_blank" title="Instagram">
-            <svg class="iconsvg"><use xlink:href="#instagram"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="{{site.mastodon}}" target="_blank" title="Mastodon">
-            <svg class="iconsvg"><use xlink:href="#mastodon"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="https://twitter.com/{{site.twitter}}" target="_blank" title="Twitter">
-            <svg class="iconsvg"><use xlink:href="#twitter"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="https://www.facebook.com/{{site.facebook}}" target="_blank" title="Facebook">
-            <svg class="iconsvg"><use xlink:href="#facebook"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="https://www.linkedin.com/{{site.linkedin}}" target="_blank" title="LinkedIn">
-            <svg class="iconsvg"><use xlink:href="#linkedin"></use></svg>
-          </a>
-        </li>
-        <li>
-          <a href="https://github.com/{{site.github}}" target="_blank" title="GitHub">
-            <svg class="iconsvg"><use xlink:href="#github"></use></svg>
-          </a>
-        </li>
+        {%- if site.youtube_page -%}
+          <li>
+            <a href="https://youtube.com/{{site.youtube_page}}" target="_blank" title="YouTube">
+              <svg class="iconsvg"><use xlink:href="#youtube"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.instagram -%}
+          <li>
+            <a href="https://instagram.com/{{site.instagram}}" target="_blank" title="Instagram">
+              <svg class="iconsvg"><use xlink:href="#instagram"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.mastodon -%}
+          <li>
+            <a href="{{site.mastodon}}" target="_blank" title="Mastodon">
+              <svg class="iconsvg"><use xlink:href="#mastodon"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.twitter -%}
+          <li>
+            <a href="https://twitter.com/{{site.twitter}}" target="_blank" title="Twitter">
+              <svg class="iconsvg"><use xlink:href="#twitter"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.facebook -%}
+          <li>
+            <a href="https://www.facebook.com/{{site.facebook}}" target="_blank" title="Facebook">
+              <svg class="iconsvg"><use xlink:href="#facebook"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.linkedin -%}
+          <li>
+            <a href="https://www.linkedin.com/{{site.linkedin}}" target="_blank" title="LinkedIn">
+              <svg class="iconsvg"><use xlink:href="#linkedin"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.github -%}
+          <li>
+            <a href="https://github.com/{{site.github}}" target="_blank" title="GitHub">
+              <svg class="iconsvg"><use xlink:href="#github"></use></svg>
+            </a>
+          </li>
+        {%- endif -%}
         <li>
           <a href="{{'/contact' | absolute_url}}" title="Email">
             <svg class="iconsvg"><use xlink:href="#envelope"></use></svg>


### PR DESCRIPTION
In setting up my own site with dogwood there didn't seem to be an easy way to deactivate social links that I do not want to display in the footer. This PR adds that ability for the following socials:

- [ ] Slack
- [X] Youtube
- [X] Instagram
- [X] Mastodon
- [X] Twitter
- [X] Facebook
- [X] LinkedIn
- [X] GitHub
- [ ] Contact page

To deactivate these, set their config values to `false` in `_config.yml`. For example:
```yaml
youtube_page: false
```

Slack and "Contact" currently link to pages within the site, so I wasn't sure how best to handle their deactivation. May we make their links configurable from `_config.yml` as well, so that they may be customized? I'm happy to file a separate issue and/or PR for those.

Thank you for your work on this theme!