### PR TITLE
make unaffiliated disclaimer on person layout customizable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,11 @@ youtube_page: channel/UCQpS2iHNVR-_6nAxt87nwCw
 facebook: openstreetmap.us
 instagram: openstreetmapus
 linkedin: company/openstreetmap-us
+unaffiliated_disclaimer: |
+  This is a compilation of publicly-available info about someone who has participated with OpenStreetMap US and is not an endorsement.
+affiliate_orgs:
+  - "OpenStreetMap US Board"
+  - "OpenStreetMap US Staff"
 links:
   - link: /plants/
   - link: /people/

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -109,16 +109,18 @@ layout: default
     <div class="section">
       <h3></h3>
       <div class="section-body prose">
-        {%- assign isExternal=true -%}
-        {%- for role in page.roles -%}
-          {%- if role.at == "OpenStreetMap US Board" or role.at == "OpenStreetMap US Staff" -%}
-            {%- assign isExternal=false -%}
-            {%- break -%}
+        {%- if site.unaffiliated_disclaimer -%}
+          {%- assign isExternal=true -%}
+          {%- for role in page.roles -%}
+            {%- if site.affiliate_orgs contains role.at -%}
+              {%- assign isExternal=false -%}
+              {%- break -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if isExternal -%}
+            <p><em>{{site.unaffiliated_disclaimer}}</em></p>
+            <p><em>Is this your page? <a href="{{site.url}}{{site.baseurl}}/contact">Contact us</a> to edit your info.</em></p>
           {%- endif -%}
-        {%- endfor -%}
-        {%- if isExternal -%}
-          <p><em>This is a compilation of publicly-available info about someone who has participated with OpenStreetMap US and is not an endorsement.</em></p>
-          <p><em>Is this your page? <a href="{{site.url}}{{site.baseurl}}/contact">Contact us</a> to edit your info.</em></p>
         {%- endif -%}
         {%- if page.updated -%}
           <p><em>Last updated {{page.updated | date: "%B %Y" }}.</em></p>


### PR DESCRIPTION
This PR allows users to easily change the default disclaimer on the person layout, or disable it altogether. This will help non-OSMUS sites use the built-in person layout more easily.

For example, with `unaffiliated_disclaimer` and `affiliate_orgs` set to different values in `_config.yml`:
```yaml
unaffiliated_disclaimer: |
  This person is altogther unaffiliated with ACME Mapping Corp., we have no idea who they are.
affiliate_orgs:
  - ACME Mapping Corp
```
Yields the following, unless of course the user has a `role` with `at: ACME Mapping Corp` in their page frontmatter:
![Screenshot from 2024-01-25 22-58-43](https://github.com/osmus/dogwood/assets/55111303/3117f782-5ccd-41f8-a17c-874421745adc)

To disable to disclaimer, set `unaffiliated_disclaimer` to `false` in `_config.yml`.