### PR TITLE
Add `rel="me"` to mastodon footer link for verification purposes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
         {%- endif -%}
         {%- if site.mastodon -%}
           <li>
-            <a href="{{site.mastodon}}" target="_blank" title="Mastodon">
+            <a href="{{site.mastodon}}" target="_blank" title="Mastodon" rel="me">
               <svg class="iconsvg"><use xlink:href="#mastodon"></use></svg>
             </a>
           </li>


### PR DESCRIPTION
This will allow OSM US to verify [openstreetmap.us](https://openstreetmap.us) on [@OpenStreetMapUS](https://en.osm.town/@OpenStreetMapUS) and MapRVA to verify [maprva.org](https://maprva.org) on [@maprva](https://en.osm.town/@maprva).