### PR TITLE
Fix accidental newline trimming in people and project page contents

### DIFF
--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -18,10 +18,10 @@ layout: default
             <a href="https://www.openstreetmap.org/user/{{page.osm}}">@{{page.osm}}</a>
           {%- endif -%}
         </div>
-        {%- assign content = page.content | strip_newlines -%}
-        {%- if content != '' -%}
+        {%- assign trimmed_content = page.content | strip_newlines -%}
+        {%- if trimmed_content != '' -%}
           <div class="section-body prose">
-            {{content}}
+            {{ page.content }}
           </div>
         {%- endif -%}
         {%- include person_roles.html person=page-%}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -49,10 +49,10 @@ layout: default
   {%- endif -%}
   <div class="content">
     <div class="container">
-      {%- assign content = page.content | strip_newlines -%}
-      {%- if content != '' -%}
+      {%- assign trimmed_content = page.content | strip_newlines -%}
+      {%- if trimmed_content != '' -%}
         <div class="prose">
-          {{- content -}}
+          {{ page.content }}
         </div>
       {%- endif -%}
       {%- include posts_section.html tag=page.title max_posts=page.max_posts -%}


### PR DESCRIPTION
Trimming newlines has unexpected effects on code blocks and other preformatted text. I think the intent was just to check if the content was empty (after trimming off extraneous whitespace) so I modified the logic to do that but to still use the original, unmodified content if it does turn out to be nonempty.