### PR TITLE
Load site metadata before page metadata in <head>

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
 <head>
-  {% include page_meta.html %}
   {% include_cached site_meta.html %}
+  {% include page_meta.html %}
 </head>


### PR DESCRIPTION
W3C wishes for `<meta charset="UTF-8">` [to be in the first 1024 bytes of the document](http://www.w3.org/TR/2012/CR-html5-20121217/document-metadata.html#charset). Putting the site meta includes before any page-specific meta guarantees this.

Making this a PR in case it has unintended consequences on OSMUS site (this seems unlikely)